### PR TITLE
MLX: workaround for torch.BFloat16Tensor + get rid of Python generator in mamba_lm_mlx.MambaLM.generate for UTF-8 multibyte characters like CJK, Thai and etc.

### DIFF
--- a/mlx/mamba_lm_mlx.py
+++ b/mlx/mamba_lm_mlx.py
@@ -87,8 +87,6 @@ class MambaLM(nn.Module):
         # the last d_conv-1 inputs because they are used in a 1d convolution (usually d_conv=4 so this is not large)
         caches = [(None, mx.zeros([1, self.config.d_conv-1, self.config.d_inner])) for _ in range(self.config.n_layers)]
 
-        yield tokenizer.decode(input_ids[:, 0].tolist())
-
         for i in range(input_ids.shape[1] + n_tokens_to_gen - 1):
             next_token_logits, caches = self.step(input_ids[:, i], caches) # (1, vocab_size), caches
 
@@ -106,11 +104,12 @@ class MambaLM(nn.Module):
                     next_token = mx.argmax(next_token_logits, axis=-1)[:, None]
 
                 input_ids = mx.concatenate([input_ids, next_token], axis=1)
-                yield tokenizer.decode(next_token.tolist()[0])
-            else:
-                yield tokenizer.decode(input_ids[:, i+1].tolist())
+
+        output = [tokenizer.decode(output.tolist()) for output in input_ids][0]
 
         self.train()
+
+        return output
     
     @staticmethod
     def from_pretrained(name: str):

--- a/mlx/misc.py
+++ b/mlx/misc.py
@@ -98,6 +98,9 @@ def torch_to_mlx_depthwise_weights(torch_weights):
     mlx_weights = torch.zeros(channels, kernel_size, channels)
 
     indices = torch.arange(channels)
-    mlx_weights[indices, :, indices] = torch_weights[:, :, 0]
+    if torch_weights[:, :, 0].type() == 'torch.BFloat16Tensor':
+        mlx_weights[indices, :, indices] = torch_weights[:, :, 0].float()
+    else:
+        mlx_weights[indices, :, indices] = torch_weights[:, :, 0]
 
     return mlx_weights

--- a/mlx/scripts/generate.py
+++ b/mlx/scripts/generate.py
@@ -35,5 +35,6 @@ if __name__ == "__main__":
     
     mx.set_default_device(mx.gpu)
 
-    for token in model.generate(tokenizer, args.prompt, n_tokens_to_gen=args.n_tokens, temperature=args.temperature, top_k=args.top_k):
-        print(token, end='', flush=True)
+    output = model.generate(tokenizer, args.prompt, n_tokens_to_gen=args.n_tokens, temperature=args.temperature, top_k=args.top_k)
+
+    print(output)

--- a/mlx/utils.py
+++ b/mlx/utils.py
@@ -34,7 +34,10 @@ def map_mambapy_torch_to_mlx(torch_state_dict):
         if 'conv1d' in key:
             key = key.replace('conv1d', 'conv1d.conv1d')
 
-        new_state_dict[key] = value.numpy()
+        if value.type() == 'torch.BFloat16Tensor':
+            new_state_dict[key] = value.half().numpy()
+        else:
+            new_state_dict[key] = value.numpy()
 
     return new_state_dict
 


### PR DESCRIPTION
MLX: workaround for torch.BFloat16Tensor
MLX: get rid of Python generator in mamba_lm_mlx.MambaLM.generate for UTF-8 multibyte characters like CJK, Thai and etc.
