### PR TITLE
Fix MLX Generation script for Python 3.11

### DIFF
--- a/mlx/misc.py
+++ b/mlx/misc.py
@@ -22,9 +22,9 @@ def unsqueeze(x, axis):
 
     assert axis <= len(x.shape)
     if axis >= 0:
-        new_shape = x.shape[:axis] + [1] + x.shape[axis:]
+        new_shape = x.shape[:axis] + tuple([1]) + x.shape[axis:]
     else:
-        new_shape = x.shape + [1]
+        new_shape = x.shape + tuple([1])
     return x.reshape(new_shape)
 
 def clamp(x, min=None, max=None):


### PR DESCRIPTION
When using python 3.11 and mlx generate script there is an error "TypeError: can only concatenate tuple (not "list") to tuple". This pull request fixes that allowing the script to execute properly.