### PR TITLE
<feat>: provide a naive onnx export

### DIFF
--- a/mamba_lm_onnx.py
+++ b/mamba_lm_onnx.py
@@ -1,0 +1,125 @@
+from dataclasses import dataclass, fields, asdict
+import json
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from mamba import Mamba, MambaConfig, RMSNorm
+
+"""
+
+Encapsulates a Mamba model as language model. It has an embedding layer, and a LM head which maps the model output to logits.
+
+"""
+
+# TODO generate function : batch size != 1 ? (for now B=1)
+# TODO generate function : top-p sampling
+
+@dataclass
+class MambaLMConfig(MambaConfig):
+    vocab_size: int = 32000
+    pad_vocab_size_multiple: int = 8
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        if self.vocab_size % self.pad_vocab_size_multiple != 0:
+            self.vocab_size += (self.pad_vocab_size_multiple - self.vocab_size % self.pad_vocab_size_multiple)
+
+    def to_mamba_config(self) -> MambaConfig:
+        mamba_config_fields = {field.name for field in fields(MambaConfig)}
+        filtered_dict = {k: v for k, v in asdict(self).items() if k in mamba_config_fields}
+        return MambaConfig(**filtered_dict)
+
+# adapted from https://github.com/johnma2006/mamba-minimal
+def from_pretrained(name: str):
+    """
+    Returns a model loaded with pretrained weights pulled from HuggingFace.
+
+    Note :
+    This only work with the state-spaces/mamba-XXX model family, because there is a pytorch_model.bin file in the HF repo.
+    This is not the case of typical model saved on HF (like the state-spaces/mamba-XXX-hf model family).
+    To load the state dict of such models, I think the only way is to load the model into a AutoModelForCausalLM, and then
+    pass the state_dict to a MambaLM. I see no other way around unfrortunately (this is how it's done in jamba.py)
+
+    Args:
+        name: As of now, supports
+            * 'state-spaces/mamba-2.8b-slimpj'
+            * 'state-spaces/mamba-2.8b'
+            * 'state-spaces/mamba-1.4b'
+            * 'state-spaces/mamba-790m'
+            * 'state-spaces/mamba-370m'
+            * 'state-spaces/mamba-130m'
+
+    Returns:
+        model: a Mamba model configured with the proper parameters and initialized with the proper weights
+    """   
+
+    from transformers.utils import WEIGHTS_NAME, CONFIG_NAME
+    from transformers.utils.hub import cached_file
+
+    def load_config_hf(model_name):
+        resolved_archive_file = cached_file(model_name, CONFIG_NAME, _raise_exceptions_for_missing_entries=False)
+        return json.load(open(resolved_archive_file))
+                
+    def load_state_dict_hf(model_name):
+        resolved_archive_file = cached_file(model_name, WEIGHTS_NAME, _raise_exceptions_for_missing_entries=False)
+        return torch.load(resolved_archive_file, weights_only=True, map_location='cpu', mmap=True)
+        
+    # copy config data
+    config_data = load_config_hf(name)
+    config = MambaLMConfig(d_model=config_data['d_model'], n_layers=config_data['n_layer'], vocab_size=config_data['vocab_size'])
+
+    model = MambaLM(config)
+
+    # copy weights
+    state_dict = load_state_dict_hf(name)
+
+    new_state_dict = {}
+    for key in state_dict:
+        if key == 'backbone.embedding.weight' or key == 'backbone.norm_f.weight':
+            new_key = key.replace('backbone.', '')
+        else:
+            new_key = key.replace('backbone', 'mamba')
+
+        new_state_dict[new_key] = state_dict[key]
+
+    model.load_state_dict(new_state_dict)
+
+    return model
+
+class MambaLM(nn.Module):
+    def __init__(self, lm_config: MambaLMConfig):
+        super().__init__()
+        self.lm_config = lm_config
+        self.config = lm_config.to_mamba_config()
+
+        self.embedding = nn.Embedding(self.lm_config.vocab_size, self.config.d_model)
+        self.mamba = Mamba(self.config)
+        self.norm_f = RMSNorm(self.config.d_model)
+
+        self.lm_head = nn.Linear(self.config.d_model, self.lm_config.vocab_size, bias=False)
+        self.lm_head.weight = self.embedding.weight
+        
+    def __caches(self):
+        return [(None, torch.zeros(1, self.config.d_inner, self.config.d_conv-1, device=next(self.parameters()).device)) for _ in range(self.config.n_layers)]
+    
+    def forward(self, token):
+        # token : (B)
+        # caches : [cache(layer) for all layers], cache : (h, inputs)
+
+        # logits : (B, vocab_size)
+        # caches : [cache(layer) for all layers], cache : (h, inputs)
+
+        x = self.embedding(token)
+        
+        caches = self.__caches()
+
+        x, caches = self.mamba.step(x, caches)
+        x = self.norm_f(x)
+
+        logits = self.lm_head(x)
+
+        return logits
+    

--- a/onnx_convert.py
+++ b/onnx_convert.py
@@ -1,13 +1,15 @@
 import torch
 from mamba_lm_onnx import from_pretrained
 
-model = from_pretrained('state-spaces/mamba-130m').to('cuda')
+model = from_pretrained('state-spaces/mamba-370m')
+model.eval()
 
-
-# Note that this may not work 
+# Note that this may not work
 # so you may need to adjust the input shape and type
-torch.onnx.export(model, 
-                  torch.zeros(1, dtype=torch.int64, device='cuda'), 
-                  'mamba-130m.onnx', 
-                  input_names=['input'], 
-                  output_names=['output'],)
+torch.onnx.export(model,
+                  torch.zeros(1, dtype=torch.int64),
+                  'mamba-370m.onnx',
+                  input_names=['input'],
+                  output_names=['output'],
+                  opset_version=17,
+                  )

--- a/onnx_convert.py
+++ b/onnx_convert.py
@@ -1,0 +1,13 @@
+import torch
+from mamba_lm_onnx import from_pretrained
+
+model = from_pretrained('state-spaces/mamba-130m').to('cuda')
+
+
+# Note that this may not work 
+# so you may need to adjust the input shape and type
+torch.onnx.export(model, 
+                  torch.zeros(1, dtype=torch.int64, device='cuda'), 
+                  'mamba-130m.onnx', 
+                  input_names=['input'], 
+                  output_names=['output'],)

--- a/onnx_usage.py
+++ b/onnx_usage.py
@@ -1,0 +1,53 @@
+import torch
+import torch.nn.functional as F
+
+from transformers import AutoTokenizer
+
+import onnxruntime as ort
+
+num_tokens = 50
+temperature = 1.0
+top_k = 40
+sample = True
+
+provider = ['CPUExecutionProvider', 'CUDAExecutionProvider']
+model = ort.InferenceSession('mamba-130m.onnx', providers=provider)
+
+
+# See https://huggingface.co/state-spaces/mamba-2.8b/discussions/3
+tokenizer = AutoTokenizer.from_pretrained('EleutherAI/gpt-neox-20b')
+
+
+inputs = input(">>> ")
+input_ids = tokenizer(inputs, return_tensors='pt').input_ids
+def to_numpy(tensor):
+    return tensor.detach().cpu().numpy() if tensor.requires_grad else tensor.cpu().numpy()
+
+for i in range(input_ids.size(1) + num_tokens - 1):
+    with torch.no_grad():
+        # print(input_ids[:, i].shape)
+        ort_input = {model.get_inputs()[0].name: to_numpy(input_ids[:, i])}
+        # return a list of outputs
+        next_token = model.run(None, ort_input)[0]
+        # convert to tensor
+        next_token = torch.from_numpy(next_token)
+    
+    if i+1 >= input_ids.size(1):
+        probs = F.softmax(next_token / temperature, dim=-1) # (batch_size, vocab_size)
+
+        if top_k is not None:
+            values, _ = torch.topk(probs, k=top_k) # (batch_size, k) ordered from lowest to biggest
+            probs[probs < values[:, -1, None]] = 0
+            probs = probs / probs.sum(axis=1, keepdims=True)
+
+        if sample:
+            next_token = torch.multinomial(probs, num_samples=1).squeeze(1) # (batch_size)
+        else:
+            next_token = torch.argmax(probs, dim=-1) # (batch_size)
+
+        input_ids = torch.cat([input_ids, next_token.unsqueeze(1)], dim=1)
+
+outputs = [tokenizer.decode(output.tolist()) for output in input_ids]
+
+
+print(outputs[0])


### PR DESCRIPTION
I have implemented code to export to an ONNX model, which can be found in `onnx_convert.py` and `mamba_lm_onnx.py`. Additionally, I have provided a usage example for ONNX in `onnx_usage.py`.