### PR TITLE
muP for Mamba and Mamba-2

### DIFF
--- a/mambapy/mamba.py
+++ b/mambapy/mamba.py
@@ -50,6 +50,9 @@ class MambaConfig:
     conv_bias: bool = True
     inner_layernorms: bool = False # apply layernorms to internal activations
 
+    mup: bool = False
+    mup_base_width: float = 128 # width=d_model
+
     pscan: bool = True # use parallel scan mode or sequential mode when training
     use_cuda: bool = False # use official CUDA implementation when training (not compatible with (b)float16)
 
@@ -58,6 +61,10 @@ class MambaConfig:
 
         if self.dt_rank == 'auto':
             self.dt_rank = math.ceil(self.d_model / 16)
+
+        # muP
+        if self.mup:
+            self.mup_width_mult = self.d_model / self.mup_base_width
 
 class Mamba(nn.Module):
     def __init__(self, config: MambaConfig):
@@ -94,7 +101,7 @@ class ResidualBlock(nn.Module):
         super().__init__()
 
         self.mixer = MambaBlock(config)
-        self.norm = RMSNorm(config.d_model, config.rms_norm_eps)
+        self.norm = RMSNorm(config.d_model, config.rms_norm_eps, config.mup)
 
     def forward(self, x):
         # x : (B, L, D)
@@ -170,9 +177,9 @@ class MambaBlock(nn.Module):
 
         # used in jamba
         if self.config.inner_layernorms:
-            self.dt_layernorm = RMSNorm(self.config.dt_rank, config.rms_norm_eps)
-            self.B_layernorm = RMSNorm(self.config.d_state, config.rms_norm_eps)
-            self.C_layernorm = RMSNorm(self.config.d_state, config.rms_norm_eps)
+            self.dt_layernorm = RMSNorm(self.config.dt_rank, config.rms_norm_eps, config.mup)
+            self.B_layernorm = RMSNorm(self.config.d_state, config.rms_norm_eps, config.mup)
+            self.C_layernorm = RMSNorm(self.config.d_state, config.rms_norm_eps, config.mup)
         else:
             self.dt_layernorm = None
             self.B_layernorm = None
@@ -407,13 +414,21 @@ class MambaBlock(nn.Module):
         return y, h
 
 class RMSNorm(nn.Module):
-    def __init__(self, d_model: int, eps: float = 1e-5):
+    def __init__(self, d_model: int, eps: float = 1e-5, use_mup: bool = False):
         super().__init__()
 
+        self.use_mup = use_mup
         self.eps = eps
-        self.weight = nn.Parameter(torch.ones(d_model))
+
+        # https://arxiv.org/abs/2404.05728, RMSNorm gains prevents muTransfer (section 4.2.3)
+        if not use_mup:
+            self.weight = nn.Parameter(torch.ones(d_model))
 
     def forward(self, x):
         output = x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + self.eps)
 
-        return output * self.weight
+        if not self.use_mup:
+            return output * self.weight
+        else:
+            return output
+    

--- a/mambapy/mamba2.py
+++ b/mambapy/mamba2.py
@@ -3,7 +3,7 @@
 """
 
 adapted from https://github.com/state-spaces/mamba/blob/main/mamba_ssm/modules/mamba2_simple.py
-It justs implements a config similar to what's being done in mamba.py.
+It justs implements a config similar to what's being done in mamba.py, as well as supports muP.
 
 """
 
@@ -56,6 +56,9 @@ class Mamba2Config:
     bias: bool = False
     conv_bias: bool = True
 
+    mup: bool = False
+    mup_base_width: float = 128 # width=d_model
+
     chunk_size: int = 256
     use_mem_eff_path: bool = True
     dtype=None
@@ -67,6 +70,10 @@ class Mamba2Config:
         assert self.d_inner % self.d_head == 0
 
         assert (self.d_inner / self.d_head) % 8 == 0, "requierement of causal_conv1d"
+
+        # muP
+        if self.mup:
+            self.mup_width_mult = self.d_model / self.mup_base_width
 
 class Mamba2(nn.Module):
     def __init__(self, config: Mamba2Config):
@@ -103,7 +110,7 @@ class ResidualBlock(nn.Module):
         super().__init__()
 
         self.mixer = Mamba2Block(config)
-        self.norm = RMSNorm(config.d_model, config.rms_norm_eps)
+        self.norm = RMSNorm(config.d_model, config.rms_norm_eps, config.mup)
 
     def forward(self, x):
         # x : (B, L, D)
@@ -152,6 +159,7 @@ class Mamba2Block(nn.Module):
             nn.init.uniform_(self.conv1d.weight, -self.config.conv_init, self.config.conv_init)
         # self.conv1d.weight._no_weight_decay = True
 
+        # todo : mup init + lr
         if self.config.learnable_init_states:
             self.init_states = nn.Parameter(torch.zeros(self.config.n_heads, self.config.d_head, self.config.d_state, **factory_kwargs))
             self.init_states._no_weight_decay = True
@@ -267,12 +275,20 @@ class Mamba2Block(nn.Module):
 
 # taken straight from https://github.com/johnma2006/mamba-minimal/blob/master/model.py
 class RMSNorm(nn.Module):
-    def __init__(self, d_model: int, eps: float = 1e-5):
+    def __init__(self, d_model: int, eps: float = 1e-5, use_mup: bool = False):
         super().__init__()
 
+        self.use_mup = use_mup
         self.eps = eps
-        self.weight = nn.Parameter(torch.ones(d_model))
+
+        # https://arxiv.org/abs/2404.05728, RMSNorm gains prevents muTransfer (section 4.2.3)
+        if not use_mup:
+            self.weight = nn.Parameter(torch.ones(d_model))
 
     def forward(self, x):
         output = x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + self.eps)
-        return output * self.weight
+
+        if not self.use_mup:
+            return output * self.weight
+        else:
+            return output

--- a/tests/coord_check.py
+++ b/tests/coord_check.py
@@ -1,7 +1,9 @@
 # Copyright 2022 Microsoft Corporation.
 
-# adapted from https://github.com/microsoft/mup
-# in short, it has been largely simplified
+"""
+Adapted from https://github.com/microsoft/mup
+In short, it has been largely simplified.
+"""
 
 import os
 from copy import copy

--- a/tests/coord_check.py
+++ b/tests/coord_check.py
@@ -1,0 +1,495 @@
+# Copyright 2022 Microsoft Corporation.
+
+# adapted from https://github.com/microsoft/mup
+# in short, it has been largely simplified
+
+import os
+from copy import copy
+from itertools import product
+
+import numpy as np
+import pandas as pd
+import torch
+import torch.nn.functional as F
+
+from tqdm import tqdm
+import matplotlib.pyplot as plt
+import seaborn as sns
+
+FDICT = {'l1': lambda x: torch.abs(x).mean(dtype=torch.float32)}
+
+def convert_fdict(d):
+    '''convert a dict `d` with string values to function values.
+    Input:
+        d: a dict whose values are either strings or functions
+    Output:
+        a new dict, with the same keys as `d`, but the string values are
+        converted to functions using `FDICT`.
+    '''
+    return dict([
+        ((k, FDICT[v]) if isinstance(v, str) else (k, v))
+        for k, v in d.items()])
+    
+def _record_coords(records, width, modulename, t,
+                output_fdict=None, input_fdict=None, param_fdict=None):
+    '''Returns a forward hook that records coordinate statistics.
+
+    Returns a forward hook that records statistics regarding the output, input,
+    and/or parameters of a `nn.Module`. This hook is intended to run only once,
+    on the timestep specified by `t`.
+
+    On forward pass, the returned hook calculates statistics specified in
+    `output_fdict`, `input_fdict`, and `param_fdict`, such as the normalized l1
+    norm, of output, input, and/or parameters of the module. The statistics are
+    recorded along with the `width`, `modulename`, and `t` (the time step) as a
+    dict and inserted into `records` (which should be a list). More precisely,
+    for each output, input, and/or parameter, the inserted dict is of the form
+
+        {
+            'width': width, 'module': modified_modulename, 't': t,
+            # keys are keys in fdict
+            'l1': 0.241, 'l2': 0.420, 'mean': 0.0, ...
+        }
+    
+    where `modified_modulename` is a string that combines the `modulename` with
+    an indicator of which output, input, or parameter tensor is the statistics
+    computed over.
+
+    The `*_fdict` inputs should be dictionaries with string keys and whose
+    values can either be functions or strings. The string values are converted
+    to functions via `convert_fdict`. The default values of `*_dict` inputs are
+    converted to `output_fdict = dict(l1=FDICT['l1'])`, `input_fdict = {}`,
+    `param_fdict = {}`, i.e., only the average coordinate size (`l1`) of the
+    output activations are recorded.
+
+    Inputs:
+        records:
+            list to append coordinate data to
+        width:
+            width of the model. This is used only for plotting coord check later
+            on, so it can be any notion of width.
+        modulename:
+            string name of the module. This is used only for plotting coord check.
+        t:
+            timestep of training. This is used only for plotting coord check.
+        output_fdict, input_fdict, param_fdict:
+            dicts with string keys and whose values can either be functions or
+            strings. The string values are converted to functions via
+            `convert_fdict`
+    Output:
+        a forward hook that records statistics regarding the output, input,
+        and/or parameters of a `nn.Module`, as discussed above.
+    '''
+    if output_fdict is None:
+        output_fdict = dict(l1=FDICT['l1'])
+    else:
+        output_fdict = convert_fdict(output_fdict)
+    if input_fdict is None:
+        input_fdict = {}
+    else:
+        input_fdict = convert_fdict(input_fdict)
+    if param_fdict is None:
+        param_fdict = {}
+    else:
+        param_fdict = convert_fdict(param_fdict)
+    def f(module, input, output):
+        def get_stat(d, x, fdict):
+            if isinstance(x, (tuple, list)):
+                for i, _x in enumerate(x):
+                    _d = copy(d)
+                    _d['module'] += f'[{i}]'
+                    get_stat(_d, _x, fdict)
+            elif isinstance(x, dict):
+                for name, _x in x.items():
+                    _d = copy(d)
+                    _d['module'] += f'[{name}]'
+                    get_stat(_d, _x, fdict)
+            elif isinstance(x, torch.Tensor):
+                _d = copy(d)
+                for fname, f in fdict.items():
+                    _d[fname] = f(x).item()
+                records.append(_d)
+            elif x is None:
+                pass
+            else:
+                raise NotImplementedError(f'Unexpected output type: {type(x)}')
+        with torch.no_grad():
+            ret = {
+                'width': width,
+                'module': modulename,
+                't': t
+            }
+
+            # output stats
+            if isinstance(output, (tuple, list)):
+                for i, out in enumerate(output):
+                    _ret = copy(ret)
+                    _ret['module'] += f':out[{i}]'
+                    get_stat(_ret, out, output_fdict)
+            elif isinstance(output, dict):
+                for name, out in output.items():
+                    _ret = copy(ret)
+                    _ret['module'] += f':out[{name}]'
+                    get_stat(_ret, out, output_fdict)
+            elif isinstance(output, torch.Tensor):
+                _ret = copy(ret)
+                for fname, f in output_fdict.items():
+                    _ret[fname] = f(output).item()
+                records.append(_ret)
+            else:
+                raise NotImplementedError(f'Unexpected output type: {type(output)}')
+
+            # input stats
+            if input_fdict:
+                if isinstance(input, (tuple, list)):
+                    for i, out in enumerate(input):
+                        _ret = copy(ret)
+                        _ret['module'] += f':in[{i}]'
+                        get_stat(_ret, out, input_fdict)
+                elif isinstance(input, dict):
+                    for name, out in input.items():
+                        _ret = copy(ret)
+                        _ret['module'] += f':in[{name}]'
+                        get_stat(_ret, out, input_fdict)
+                elif isinstance(input, torch.Tensor):
+                    _ret = copy(ret)
+                    for fname, f in input_fdict.items():
+                        _ret[fname] = f(input).item()
+                    records.append(_ret)
+                else:
+                    raise NotImplementedError(f'Unexpected output type: {type(input)}')
+
+            # param stats
+            if param_fdict:
+                for name, p in module.named_parameters():
+                    _ret = copy(ret)
+                    _ret['module'] += f':param[{name}]'
+                    for fname, f in param_fdict.items():
+                        _ret[fname] = f(p).item()
+                    records.append(_ret)
+
+    return f
+
+def _get_coord_data(models, dataloader, optcls, nsteps=5,
+                dict_in_out=False, flatten_input=False, flatten_output=False, 
+                output_name='loss', lossfn='xent', filter_module_by_name=None,
+                fix_data=True, cuda=True, nseeds=1, 
+                output_fdict=None, input_fdict=None, param_fdict=None,
+                show_progress=True, one_hot_target=False):
+    '''Inner method for `get_coord_data`.
+
+    Train the models in `models` with optimizer given by `optcls` and data from
+    `dataloader` for `nsteps` steps, and record coordinate statistics specified
+    by `output_fdict`, `input_fdict`, `param_fdict`. By default, only `l1` is
+    computed for output activations of each module.
+
+    Inputs:
+        models: 
+            a dict of lazy models, where the keys are numbers indicating width.
+            Each entry of `models` is a function that instantiates a model given
+            nothing.
+        dataloader:
+            an iterator whose elements are either Huggingface style dicts, if
+            `dict_in_out` is True, or (input, label). If `fix_data` is True
+            (which is the default), then only the first element of `dataloader`
+            is used in a loop and the rest of `dataloder` is ignored.
+        optcls: 
+            a function so that `optcls(model)` gives an optimizer used to train
+            the model.
+        nsteps: 
+            number of steps to train the model
+        dict_in_out:
+            whether the data loader contains Huggingface-style dict input and
+            output. Default: False
+        flatten_input:
+            if not `dict_in_out`, reshape the input to be
+            `input.view(input.shape[0], -1)`. Typically used for testing MLPs.
+        flatten_output:
+            if not `dict_in_out`, reshape the label to be `label.view(-1,
+            input.shape[-1])`.
+        output_name:
+            if `dict_in_out`, this is the key for the loss value if the output
+            is a dict. If the output is not a dict, then we assume the first
+            element of the output is the loss.
+        lossfn:
+            loss function to use if not `dict_in_out`. Can be either a string from
+            [`xent`, 'mse', 'nll', 'l1'] or a python `callable` such that
+            `lossfn(output, target)` returns the loss value. Examples of valid
+            `callable`s are `F.cross_entropy`, `F.mse_loss`, etc, where `F` is
+            `torch.nn.functional`. Default: 'xent'
+        filter_module_by_name:
+            a function that returns a bool given module names (from
+            `model.named_modules()`), or None. If not None, then only modules
+            whose name yields True will be recorded.
+        cuda:
+            whether to use cuda or not. Default: True
+        nseeds:
+            number of times to repeat the training, each with different seeds.
+        output_fdict, input_fdict, param_fdict: 
+            function dicts to be used in `_record_coords`. By default, only `l1`
+            is computed for output activations of each module.
+        show_progress:
+            show progress using tqdm. Default: True
+        one_hot_target:
+            convert target label into a one-hot vector. This typically is only
+            used for `'mse'` or `'l1'` losses in classification tasks.
+            Default: False
+    Output:
+        a pandas DataFrame containing recorded results. The column names are
+        `'width', 'module', 't'` as well as names of statistics recorded, such
+        as `'l1'` (see `FDICT` for other premade statistics that can be
+        collected).
+        
+    Breaking Changes:
+        In v1.0.0, when `lossfn=='mse'`, the target is automatically converted
+        to a one hot vector before loss computation. Starting in v1.1.0, this
+        behavior is turned off, and the user needs to explicitly turn on this
+        behavior by setting `one_hot_target=True`.
+    
+    '''
+    df = []
+    if fix_data:
+        batch = next(iter(dataloader))
+        dataloader = [batch] * nsteps
+    if show_progress:
+        pbar = tqdm(total=nseeds * len(models))
+
+    for i in range(nseeds):
+        torch.manual_seed(i)
+        for width, model in models.items():
+            model = model()
+            model = model.train()
+            if cuda:
+                model = model.cuda()
+            optimizer = optcls(model)
+            for batch_idx, batch in enumerate(dataloader, 1):
+                remove_hooks = []
+                # add hooks
+                for name, module in model.named_modules():
+                    if filter_module_by_name and not filter_module_by_name(name):
+                        continue
+                    remove_hooks.append(module.register_forward_hook(
+                        _record_coords(df, width, name, batch_idx,
+                            output_fdict=output_fdict,
+                            input_fdict=input_fdict,
+                            param_fdict=param_fdict)))
+                if dict_in_out:
+                    if cuda:                        
+                        for k, v in batch.items():
+                            if isinstance(v, torch.Tensor):
+                                batch[k] = v.cuda()
+                    outputs = model(**batch)
+                    loss = outputs[output_name] if isinstance(outputs, dict) else outputs[0]
+                else:
+                    (data, target) = batch
+                    if cuda:
+                        data, target = data.cuda(), target.cuda()
+                    if flatten_input:
+                        data = data.view(data.size(0), -1)
+                    output = model(data)
+                    if flatten_output:
+                        output = output.view(-1, output.shape[-1])
+                    if one_hot_target:
+                        target = F.one_hot(target, num_classes=output.size(-1)).float()
+                    if lossfn == 'xent':
+                        loss = F.cross_entropy(output.view(-1, output.size(-1)), target.view(-1), ignore_index=17)
+                    elif lossfn == 'mse':
+                        loss = F.mse_loss(output, target)
+                    elif lossfn == 'nll':
+                        loss = F.nll_loss(output, target)
+                    elif lossfn == 'l1':
+                        loss = F.l1_loss(output, target)
+                    elif callable(lossfn):
+                        loss = lossfn(output, target)
+                    else:
+                        raise NotImplementedError(f'unknown `lossfn`: {lossfn}')
+                optimizer.zero_grad()
+                loss.backward()
+                optimizer.step()
+                
+                # remove hooks
+                for handle in remove_hooks:
+                    handle.remove()
+
+                if batch_idx == nsteps: break
+            if show_progress:
+                pbar.update(1)
+    if show_progress:
+        pbar.close()
+    return pd.DataFrame(df)
+
+
+def get_coord_data(models, dataloader, optcls, nsteps, **kwargs):
+    '''Get coord data for coord check.
+
+    Train the models in `models` with data from `dataloader` and optimizer
+    specified by `optimizer` and `lr` for `nsteps` steps, and record coordinate
+    statistics specified by `output_fdict`, `input_fdict`, `param_fdict`. By
+    default, only `l1` is computed for output activations of each module.
+
+    This function wraps around `_get_coord_data`, with the main difference being
+    user can specify common optimizers via a more convenient interface.
+
+    Inputs:
+        models: 
+            a dict of lazy models, where the keys are numbers indicating width.
+            Each entry of `models` is a function that instantiates a model given
+            nothing.
+        dataloader:
+            an iterator whose elements are either Huggingface style dicts, if
+            `dict_in_out` is True, or (input, label). If `fix_data` is True
+            (which is the default), then only the first element of `dataloader`
+            is used in a loop and the rest of `dataloder` is ignored.
+        optimizer:
+            a string in `['sgd', 'adam', 'adamw']`, with default being `'sgd'`.
+        lr: 
+            learning rate. By default is 0.1 for `'sgd'` and 1e-3 for others.
+        mup: 
+            If True, then use the optimizer from `mup.optim`; otherwise, use the
+            one from `torch.optim`.
+        filter_trainable_by_name: 
+            a function that returns a bool given module names (from
+            `model.named_modules()`), or None. If not None, then only modules
+            whose name yields True will be trained.
+        nsteps: 
+            number of steps to train the model
+        dict_in_out:
+            whether the data loader contains Huggingface-style dict input and
+            output. Default: False
+        flatten_input:
+            if not `dict_in_out`, reshape the input to be
+            `input.view(input.shape[0], -1)`. Typically used for testing MLPs.
+        flatten_output:
+            if not `dict_in_out`, reshape the label to be `label.view(-1,
+            input.shape[-1])`.
+        output_name:
+            if `dict_in_out`, this is the key for the loss value if the output
+            is a dict. If the output is not a dict, then we assume the first
+            element of the output is the loss.
+        lossfn:
+            loss function to use if not `dict_in_out`. Can be either a string from
+            [`xent`, 'mse', 'nll', 'l1'] or a python `callable` such that
+            `lossfn(output, target)` returns the loss value. Examples of valid
+            `callable`s are `F.cross_entropy`, `F.mse_loss`, etc, where `F` is
+            `torch.nn.functional`. Default: 'xent'
+        filter_module_by_name:
+            a function that returns a bool given module names (from
+            `model.named_modules()`), or None. If not None, then only modules
+            whose name yields True will be recorded.
+        cuda:
+            whether to use cuda or not. Default: True
+        nseeds:
+            number of times to repeat the training, each with different seeds.
+        output_fdict, input_fdict, param_fdict: 
+            function dicts to be used in `_record_coords`. By default, only `l1`
+            is computed for output activations of each module.
+        show_progress:
+            show progress using tqdm. Default: True
+        one_hot_target:
+            convert target label into a one-hot vector. This typically is only
+            used for `'mse'` or `'l1'` losses in classification tasks.
+            Default: False
+    Output:
+        a pandas DataFrame containing recorded results. The column names are
+        `'width', 'module', 't'` as well as names of statistics recorded, such
+        as `'l1'` (see `FDICT` for other premade statistics that can be
+        collected).
+        
+    Breaking Changes:
+        In v1.0.0, when `lossfn=='mse'`, the target is automatically converted
+        to a one hot vector before loss computation. Starting in v1.1.0, this
+        behavior is turned off, and the user needs to explicitly turn on this
+        behavior by setting `one_hot_target=True`.
+    '''
+    
+    data = _get_coord_data(models, dataloader, optcls, nsteps, **kwargs)
+    return data
+
+
+def plot_coord_data(df, y='l1', save_to=None, suptitle=None, x='width', hue='module',
+                    legend='full', name_contains=None, name_not_contains=None, module_list=None,
+                    loglog=True, logbase=2, face_color=None, subplot_width=5,
+                    subplot_height=4):
+    '''Plot coord check data `df` obtained from `get_coord_data`.
+
+    Input:
+        df:
+            a pandas DataFrame obtained from `get_coord_data`
+        y:
+            the column of `df` to plot on the y-axis. Default: `'l1'`
+        save_to:
+            path to save the resulting figure, or None. Default: None.
+        suptitle:
+            The title of the entire figure.
+        x:
+            the column of `df` to plot on the x-axis. Default: `'width'`
+        hue:
+            the column of `df` to represent as color. Default: `'module'`
+        legend:
+            'auto', 'brief', 'full', or False. This is passed to `seaborn.lineplot`.
+        name_contains, name_not_contains:
+            only plot modules whose name contains `name_contains` and does not contain `name_not_contains`
+        module_list:
+            only plot modules that are given in the list, overrides `name_contains` and `name_not_contains`
+        loglog:
+            whether to use loglog scale. Default: True
+        logbase:
+            the log base, if using loglog scale. Default: 2
+        face_color:
+            background color of the plot. Default: None (which means white)
+        subplot_width, subplot_height:
+            The width and height for each timestep's subplot. More precisely,
+            the figure size will be
+                `(subplot_width*number_of_time_steps, subplot_height)`.
+            Default: 5, 4
+
+    Output:
+        the `matplotlib` figure object
+    '''
+    ### preprocessing
+    df = copy(df)
+    df = df[df.module != ''] # nn.Sequential has name '', which duplicates the output layer
+    if module_list is not None:
+        df = df[df['module'].isin(module_list)]
+    else:
+        if name_contains is not None:
+            df = df[df['module'].str.contains(name_contains)]
+        if name_not_contains is not None:
+            df = df[~(df['module'].str.contains(name_not_contains))]
+    try:
+        df['module'] = pd.to_numeric(df['module']) # for nn.Sequential, module names are numerical
+    except ValueError:
+        pass
+
+    ts = df.t.unique()
+
+    sns.set()
+
+    def tight_layout(plt):
+        plt.tight_layout(rect=[0, 0.03, 1, 0.95])
+
+    ### plot
+    fig = plt.figure(figsize=(subplot_width * len(ts), subplot_height))
+    hue_order = sorted(set(df['module']))
+    if face_color is not None:
+        fig.patch.set_facecolor(face_color)
+    ymin, ymax = min(df[y]), max(df[y])
+    for t in ts:
+        t = int(t)
+        plt.subplot(1, len(ts), t)
+        sns.lineplot(x=x, y=y, data=df[df.t == t], hue=hue, hue_order=hue_order, legend=None) # to show legend, set legend if t == 1 else None
+        plt.title(f't={t}')
+        if t != 1:
+            plt.ylabel('')
+        if loglog:
+            plt.loglog(base=logbase)
+        ax = plt.gca()
+        ax.set_ylim([ymin, ymax])
+    if suptitle:
+        plt.suptitle(suptitle)
+    tight_layout(plt)
+    if save_to is not None:
+        plt.savefig(save_to)
+        print(f'coord check plot saved to {save_to}')
+
+    return fig

--- a/tests/lr_sweep.py
+++ b/tests/lr_sweep.py
@@ -13,7 +13,6 @@ import seaborn as sns
 from tqdm import tqdm
 
 import torch
-import torch.nn as nn
 import torch.nn.functional as F
 
 import sys

--- a/tests/lr_sweep.py
+++ b/tests/lr_sweep.py
@@ -1,0 +1,130 @@
+"""
+Adapted from the example in https://github.com/graphcore-research/unit-scaling.
+They use it to benchmark u-muP, a newer version of muP.
+"""
+
+import os
+from typing import *
+
+import datasets
+import pandas as pd
+import matplotlib.pyplot as plt
+import seaborn as sns
+from tqdm import tqdm
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+import sys
+sys.path.append('..')
+from mambapy.mamba import MambaConfig
+from mambapy.mamba2 import Mamba2Config
+from mambapy.lm import LM
+
+# Config & helpers
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+
+# Model
+vocab_size = 256
+depth = 4
+head_size = 16
+mlp_expansion = 2
+
+# Training
+n_steps = int(5e3)
+warmup_steps = int(1e3)
+batch_size = 16
+sequence_length = 256
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+compile = True
+
+dataset = datasets.load_dataset("Salesforce/wikitext", "wikitext-103-raw-v1", split="train")
+data = torch.frombuffer(bytearray("".join(dataset["text"]), encoding="utf8"), dtype=torch.uint8)
+def batches():
+    for _ in range(n_steps):
+        yield torch.stack([
+            data[i:i + sequence_length].to(device=device, dtype=torch.long)
+            for i in torch.randint(0, len(data) - sequence_length, size=(batch_size,))
+        ])
+
+def lr_schedule(step: int) -> float:
+    if step < warmup_steps:
+        return step / warmup_steps
+    a = (step - warmup_steps) * torch.pi / (n_steps - warmup_steps)
+    return torch.tensor(a).cos().mul(.5).add(.5)
+
+def run_experiment(type_: Literal["SP", "μP"], width: int, lr: float) -> List[Dict[str, Any]]:
+    if type_ == "μP":
+        #config = MambaConfig(d_model=width, n_layers=depth, mup=True, mup_base_width=64, use_cuda=True)
+        config = Mamba2Config(d_model=width, n_layers=depth, d_head=head_size, mup=True, mup_base_width=64)
+        model = LM(config, vocab_size).to(device)
+    elif type_ == "SP":
+        #config = MambaConfig(d_model=width, n_layers=depth, mup=False, use_cuda=True)
+        config = Mamba2Config(d_model=width, n_layers=depth, d_head=head_size, mup=False)
+        model = LM(config, vocab_size).to(device)
+    opt = model.configure_optimizers(weight_decay=0., learning_rate=torch.tensor(lr, dtype=torch.float, device=device), betas=(0.9, 0.95), device_type=device)
+
+    schedule = torch.optim.lr_scheduler.LambdaLR(opt, lr_schedule)
+
+    def run_step(batch):
+        opt.zero_grad()
+        logits = model(batch)
+        loss = F.cross_entropy(logits[..., :-1, :].flatten(end_dim=-2), batch[..., 1:].flatten())
+        loss.backward()
+        torch.nn.utils.clip_grad_value_(model.parameters(), clip_value=1.0)
+        opt.step()
+        schedule.step()
+        return loss
+
+    log = []
+    log2lr = torch.tensor(lr).log2().item()
+    progress = tqdm(enumerate(batches()), desc=f"{type_:>4}, width={width}, lr=2^{log2lr:<5.0f}")
+    for step, batch in progress:
+        loss = run_step(batch)
+
+        if loss.item()>6:
+            print("eeee")
+        log.append(dict(step=step, loss=loss.item()))
+        if (step + 1) % 100 == 0:
+            progress.set_postfix_str(f"loss = {loss.item():.2f}")
+    return pd.DataFrame.from_dict(log).assign(type=type_, width=width, lr=lr)
+
+
+# ---------------
+
+filename = "mamba2.results.json"
+fig_name = "mamba2.png"
+
+if os.path.exists(filename):
+    with open(filename, "r") as f:
+        existing_results = pd.read_json(f)
+else:
+    existing_results = pd.DataFrame()
+
+
+type_to_lr_range = {
+    "SP": [2**n for n in range(-16, -10 + 1)],
+    "μP": [2**n for n in range(-13, -4 + 1)],
+}
+new_results = pd.concat([
+        run_experiment(type_=type_, width=width, lr=lr)
+        for type_, lrs in type_to_lr_range.items()
+        for width in [2048]
+        for lr in lrs
+]).reset_index(drop=True)
+combined_results = pd.concat([existing_results, new_results]).reset_index(drop=True)
+combined_results.to_json(filename)
+
+combined_results["loss"] = combined_results["loss"].fillna(2.)
+df_final = combined_results.groupby(["type", "width", "lr"])["loss"].apply(lambda g: min(g.iloc[-50:].mean(), 2.)).reset_index()
+
+g = sns.relplot(data=df_final.pipe(lambda d: d.assign(width=d.width.apply(str))),
+                y="loss", x="lr", hue="width", col="type",
+                kind="line", facet_kws=dict(sharex=False), height=4)
+for type_, ax in g.axes_dict.items():
+    ax.set_title(type_)
+    ax.set_xscale("log", base=2)
+
+g.savefig(fig_name, dpi=600)

--- a/tests/make_coord_check_mamba.py
+++ b/tests/make_coord_check_mamba.py
@@ -1,0 +1,50 @@
+import torch
+from torch.utils.data import Dataset, DataLoader
+
+import sys
+sys.path.append('..')
+from mambapy.mamba import MambaConfig
+from mambapy.lm import LM
+
+from coord_check import get_coord_data, plot_coord_data
+
+use_mup = True
+lr = 2e-3
+
+batch_size = 64
+batch_len = 256
+max_value = 100
+
+widths = [64, 128, 256, 512, 1024]
+n_layers = 8
+
+class RandomDataset(Dataset):
+    def __len__(self):
+        return 9999999
+
+    def __getitem__(self, idx):
+        data = torch.randint(low=0, high=max_value, size=(batch_size, batch_len))
+        x = data[:, :-1].int()
+        y = data[:, 1:].long()
+        return x, y
+
+def lazy_model(width):
+    config = MambaConfig(d_model=width, n_layers=n_layers, mup=use_mup, mup_base_width=widths[0], use_cuda=True)
+    return lambda: LM(config, vocab_size=max_value).to("cuda")
+
+models = {width: lazy_model(width) for width in widths}
+
+dataset = RandomDataset()
+loader = DataLoader(dataset, batch_size=None, shuffle=True)
+iter_ = iter(loader)
+
+optcls = lambda model: model.configure_optimizers(0.1, lr, (0.9, 0.95), "cuda")
+
+df = get_coord_data(models, iter_, optcls, nsteps=10)
+
+if use_mup:
+    name = "mamba_mup.png"
+else:
+    name = "mamba.png"
+
+plot_coord_data(df, legend="auto", save_to=name)

--- a/tests/make_coord_check_mamba2.py
+++ b/tests/make_coord_check_mamba2.py
@@ -1,0 +1,52 @@
+import numpy as np
+
+import torch
+from torch.utils.data import Dataset, DataLoader
+
+import sys
+sys.path.append('..')
+from mambapy.mamba2 import Mamba2Config
+from mambapy.lm import LM
+
+from coord_check import get_coord_data, plot_coord_data
+
+use_mup = True
+lr = 2e-3
+
+batch_size = 64
+batch_len = 256
+max_value = 100
+
+widths = [64, 128, 256, 512, 1024, 2048]
+n_layers = 8
+
+class RandomDataset(Dataset):
+    def __len__(self):
+        return 9999999
+
+    def __getitem__(self, idx):
+        data = torch.randint(low=0, high=max_value, size=(batch_size, batch_len))
+        x = data[:, :-1].int()
+        y = data[:, 1:].long()
+        return x, y
+
+def lazy_model(width):
+    config = Mamba2Config(d_model=width, n_layers=n_layers, d_head=16, mup=use_mup, mup_base_width=widths[0])
+    return lambda: LM(config, vocab_size=max_value).to("cuda")
+
+models = {width: lazy_model(width) for width in widths}
+
+dataset = RandomDataset()
+loader = DataLoader(dataset, batch_size=None, shuffle=True)
+iter_ = iter(loader)
+
+optcls = lambda model: model.configure_optimizers(0.1, lr, (0.9, 0.95), "cuda")
+
+df = get_coord_data(models, iter_, optcls, nsteps=10)
+
+if use_mup:
+    name = "mamba2_mup.png"
+else:
+    name = "mamba2.png"
+
+plot_coord_data(df, legend="full", save_to=name)


### PR DESCRIPTION
This PR adds the muP implementation with Mamba and Mamba-2.
muP is a special parametrization of the model that ensures that the network activations behave the same no matter the width (for "width", you can simply read "d_model" ie model dimension).

This makes it so that hyperparameters like learning rate and init standard deviation are the same, no matter if `d_model=64` or `d_model=2048`. This is thus incredibly useful to find the optimal HPs to train a (target) large model :
- first sweep to look for the optimal HPs at a (base) small model
- zero-shot transfer the HPs you found to train the target model

This is called **muTransfer**. So **muP** allows **muTransfer**.

See belows for checks that ensure that these muP implementations are correct.

_(this is the second PR, made in order to see in one place all the changes requiered to implement muP with Mamba. The older PR was reverted)_