### PR TITLE
Adding activation checkpointing for BPTT with pscan

### DIFF
--- a/mambapy/checkpointing.py
+++ b/mambapy/checkpointing.py
@@ -1,0 +1,191 @@
+import torch
+
+"""
+
+Activation checkpointing for stateful sequence models (Mamba, etc).
+
+Standard PyTorch checkpointing (torch.utils.checkpoint) doesn't work with pscan
+because it operates in-place. This module provides a custom checkpointing mechanism
+that stores only the small state tensors at segment boundaries, not the full activations.
+
+The idea is to split a long sequence into segments and process them one at a time :
+- Forward : run all segments without saving activations, store only states at segment boundaries
+- Backward : recompute activations one segment at a time, propagating gradients through states
+
+This gives us BPTT (backpropagation through time) with constant memory usage.
+
+Memory : O(1 segment's activations + n_segments * state_size) instead of O(n_segments * activations)
+Compute : 2x forward (once in forward, once in backward for recomputation)
+
+"""
+
+class SequenceCheckpoint(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, dummy, model, n_layers, tuple_size, num_state_tensors, *tensors):
+        # dummy : (1,) requires_grad=True, anchor for autograd graph
+        # model : callable (x, state) -> (y, new_state)
+        # n_layers : number of layers
+        # tuple_size : size of each layer's state tuple
+        # num_state_tensors : n_layers * tuple_size
+        # *tensors : (*initial_state_flat, *segments)
+
+        ctx.model = model
+        ctx.n_layers = n_layers
+        ctx.tuple_size = tuple_size
+        ctx.num_state_tensors = num_state_tensors
+
+        initial_state_flat = tensors[:num_state_tensors]
+        segments = tensors[num_state_tensors:]
+
+        ctx.initial_state = tuple(t.detach() if t is not None else None for t in initial_state_flat)
+        ctx.state_requires_grad = [t.requires_grad if t is not None else False for t in initial_state_flat]
+        ctx.num_segments = len(segments)
+
+        state_flat = list(initial_state_flat)
+        outputs = []
+        states_at_boundaries = [] # states at the beginning of each segment
+
+        # forward without saving activations
+        with torch.no_grad():
+            for x in segments:
+                states_at_boundaries.append(
+                    [t.detach().clone() if t is not None else None for t in state_flat]
+                )
+
+                state = [
+                    tuple(t.detach() if t is not None else None
+                          for t in state_flat[j * tuple_size : (j + 1) * tuple_size])
+                    for j in range(n_layers)
+                ]
+                y, new_state = model(x.detach(), state)
+
+                outputs.append(y.detach().requires_grad_(True))
+                state_flat = [
+                    t.clone() if t is not None else None
+                    for layer_tuple in new_state for t in layer_tuple
+                ]
+
+        final_state = tuple(t.requires_grad_(True) if t is not None else None for t in state_flat)
+
+        # save segments and boundary states for backward recomputation
+        states_flat_for_saving = [t for sl in states_at_boundaries for t in sl if t is not None]
+        ctx.states_none_mask = [[t is None for t in sl] for sl in states_at_boundaries]
+        ctx.save_for_backward(*segments, *states_flat_for_saving)
+
+        return (*outputs, *final_state)
+
+    @staticmethod
+    def backward(ctx, *grad_outputs):
+        num_segments = ctx.num_segments
+        grad_ys = list(grad_outputs[:num_segments])
+        grad_final_state = list(grad_outputs[num_segments:])
+
+        all_saved = ctx.saved_tensors
+        segments = all_saved[:num_segments]
+        saved_states_flat = all_saved[num_segments:]
+
+        # reconstruct boundary states
+        states = {}
+        it = iter(saved_states_flat)
+        for i, none_mask in enumerate(ctx.states_none_mask):
+            states[i] = [None if is_none else next(it) for is_none in none_mask]
+
+        # process segments in reverse, propagating gradients through states
+        current_grad_state = grad_final_state
+        grad_segments = {}
+
+        for i in range(num_segments - 1, -1, -1):
+            state_at_i = [t.detach().requires_grad_(True) if t is not None else None for t in states.pop(i)]
+
+            seg_detached = segments[i].detach().requires_grad_(True)
+            with torch.enable_grad():
+                state = [
+                    tuple(state_at_i[k * ctx.tuple_size : (k + 1) * ctx.tuple_size])
+                    for k in range(ctx.n_layers)
+                ]
+                y, new_state = ctx.model(seg_detached, state)
+                flat_new_state = [t for layer_tuple in new_state for t in layer_tuple]
+
+            # combine output grad and state grad from later segments
+            outputs = [y] + flat_new_state
+            grads = [grad_ys[i]] + current_grad_state
+
+            filtered = [(o, g) for o, g in zip(outputs, grads) if g is not None]
+            if not filtered:
+                current_grad_state = [None] * ctx.num_state_tensors
+                grad_segments[i] = None
+                continue
+
+            filtered_outputs, filtered_grads = zip(*filtered)
+
+            state_is_not_none = [t is not None for t in state_at_i]
+            state_inputs = [t for t in state_at_i if t is not None]
+
+            grad_targets = state_inputs + [seg_detached]
+            if grad_targets:
+                all_grads = list(torch.autograd.grad(
+                    filtered_outputs, grad_targets, filtered_grads,
+                    retain_graph=True, allow_unused=True,
+                ))
+
+                num_si = len(state_inputs)
+                state_grads = all_grads[:num_si]
+                grad_segments[i] = all_grads[num_si] if num_si < len(all_grads) else None
+
+                if state_inputs:
+                    current_grad_state = []
+                    gi = iter(state_grads)
+                    for not_none in state_is_not_none:
+                        current_grad_state.append(next(gi) if not_none else None)
+                else:
+                    current_grad_state = [None] * ctx.num_state_tensors
+            else:
+                current_grad_state = [None] * ctx.num_state_tensors
+                grad_segments[i] = None
+
+            # backward through model parameters
+            torch.autograd.backward(filtered_outputs, filtered_grads, retain_graph=False)
+
+        # only return gradients for initial state positions that had requires_grad
+        full_grad_initial_state = [
+            current_grad_state[j] if ctx.state_requires_grad[j] else None
+            for j in range(ctx.num_state_tensors)
+        ]
+        seg_grads = [grad_segments.get(i) for i in range(num_segments)]
+
+        return (None, None, None, None, None, *full_grad_initial_state, *seg_grads)
+
+
+def checkpointed_sequence(model, segments, initial_state):
+    # model : callable (x, state) -> (y, new_state), eg model.chunk_step
+    # segments : list of (B, seg_len, D)
+    # initial_state : [(h, inputs), ...] per layer, h can be None
+    #
+    # returns (outputs, final_state)
+
+    if not segments:
+        return [], list(initial_state)
+
+    n_layers = len(initial_state)
+    tuple_size = len(initial_state[0]) if initial_state else 0
+    initial_state_flat = [t for layer_tuple in initial_state for t in layer_tuple]
+
+    # dummy tensor to anchor the autograd graph (needed when inputs don't require grad)
+    device = segments[0].device if segments else 'cpu'
+    dtype = segments[0].dtype if segments else torch.float32
+    dummy = torch.zeros(1, device=device, dtype=dtype, requires_grad=True)
+
+    results = SequenceCheckpoint.apply(
+        dummy, model, n_layers, tuple_size, len(initial_state_flat),
+        *initial_state_flat, *segments,
+    )
+
+    num_segments = len(segments)
+    outputs = list(results[:num_segments])
+    final_state_flat = results[num_segments:]
+    final_state = [
+        tuple(final_state_flat[i * tuple_size : (i + 1) * tuple_size])
+        for i in range(n_layers)
+    ]
+
+    return outputs, final_state

--- a/mambapy/mamba.py
+++ b/mambapy/mamba.py
@@ -110,6 +110,27 @@ class Mamba(nn.Module):
         
         return x_seq, caches
 
+    def checkpointed_chunk_step(self, x_seq, caches, segment_size):
+        # x_seq : (B, L, D)
+        # caches : [cache(layer) for all layers], cache : (h, inputs)
+        # segment_size : int
+
+        # y_seq : (B, L, D)
+        # caches : [cache(layer) for all layers], cache : (h, inputs)
+
+        # same as chunk_step, but with activation checkpointing for memory-efficient BPTT
+
+        from mambapy.checkpointing import checkpointed_sequence
+
+        L = x_seq.size(1)
+        num_segments = (L + segment_size - 1) // segment_size
+        segments = [x_seq[:, i * segment_size : (i + 1) * segment_size] for i in range(num_segments)]
+
+        outputs, final_state = checkpointed_sequence(self.chunk_step, segments, caches)
+        y_seq = torch.cat(outputs, dim=1)
+
+        return y_seq, final_state
+
 class ResidualBlock(nn.Module):
     def __init__(self, config: MambaConfig):
         super().__init__()

--- a/tests/test_checkpointing.py
+++ b/tests/test_checkpointing.py
@@ -1,0 +1,142 @@
+
+import gc
+
+import torch
+
+from mambapy.mamba import Mamba, MambaConfig
+from mambapy.checkpointing import checkpointed_sequence
+
+
+def _make_mamba(d_model=32, n_layers=2, d_state=16):
+    cfg = MambaConfig(
+        d_model=d_model,
+        n_layers=n_layers,
+        d_state=d_state,
+        pscan=True,
+        use_cuda=False,
+    )
+    return Mamba(cfg)
+
+
+def _empty_caches(model, B, device='cpu'):
+    # caches : [cache(layer) for all layers], cache : (h, inputs)
+            # h : (B, ED, N)
+            # inputs : (B, ED, d_conv-1)
+    caches = []
+    for layer in model.layers:
+        cfg = layer.mixer.config
+        ED = cfg.d_inner
+        k = max(cfg.d_conv - 1, 0)
+        inputs = torch.zeros(B, ED, k, device=device)
+        caches.append((None, inputs))
+    return caches
+
+
+def test_full_forward_vs_checkpointed_gradients():
+    # full forward+backward on a single sequence must produce
+    # the same loss and gradients as 2-segment checkpointed
+    torch.manual_seed(42)
+
+    B, L, D = 4, 160, 64
+    n_layers = 4
+    segment_size = 80 # 2 segments
+    num_segments = L // segment_size
+
+    config = MambaConfig(d_model=D, n_layers=n_layers, d_state=16, pscan=True, use_cuda=False)
+
+    torch.manual_seed(123)
+    model_full = Mamba(config)
+    torch.manual_seed(123)
+    model_ckpt = Mamba(config)
+
+    for (n1, p1), (_, p2) in zip(model_full.named_parameters(), model_ckpt.named_parameters()):
+        assert torch.equal(p1, p2), f"Parameter {n1} not identical at init"
+
+    torch.manual_seed(456)
+    x = torch.randn(B, L, D, requires_grad=True)
+
+    # full forward (standard training path)
+    output_full = model_full(x)
+    loss_full = output_full.sum()
+    loss_full.backward()
+
+    # 2-segment checkpointed
+    segments = [x[:, i * segment_size : (i + 1) * segment_size] for i in range(num_segments)]
+    caches = _empty_caches(model_ckpt, B)
+    outputs_ckpt, _ = checkpointed_sequence(model_ckpt.chunk_step, segments, caches)
+    output_ckpt = torch.cat(outputs_ckpt, dim=1)
+    loss_ckpt = output_ckpt.sum()
+    loss_ckpt.backward()
+
+    assert torch.allclose(loss_full, loss_ckpt, rtol=1e-5, atol=1e-5)
+    assert torch.allclose(output_full, output_ckpt, rtol=1e-5, atol=1e-5)
+
+    for (name_f, p_f), (_, p_c) in zip(model_full.named_parameters(), model_ckpt.named_parameters()):
+        assert p_f.grad is not None and p_c.grad is not None
+        max_diff = (p_f.grad - p_c.grad).abs().max().item()
+        assert torch.allclose(p_f.grad, p_c.grad, rtol=1e-5, atol=1e-5), \
+            f"Gradient mismatch for {name_f}: max diff={max_diff:.2e}"
+
+
+def test_checkpointing_reduces_memory():
+    # checkpointed (10 x 100) must use at least 5x less peak memory than full (1 x 1000)
+    if torch.cuda.is_available():
+        device = torch.device('cuda')
+    elif torch.backends.mps.is_available():
+        device = torch.device('mps')
+    else:
+        return # skip, no GPU
+
+    B, L, D = 4, 1000, 128
+    n_layers = 8
+    segment_size = 100
+    num_segments = L // segment_size
+
+    config = MambaConfig(d_model=D, n_layers=n_layers, d_state=16, pscan=True, use_cuda=False)
+
+    def run_full():
+        torch.manual_seed(42)
+        model = Mamba(config).to(device)
+        x = torch.randn(B, L, D, device=device, requires_grad=True)
+        loss = model(x).sum()
+        loss.backward()
+
+    def run_checkpointed():
+        torch.manual_seed(42)
+        model = Mamba(config).to(device)
+        x = torch.randn(B, L, D, device=device, requires_grad=True)
+        segments = [x[:, i * segment_size : (i + 1) * segment_size] for i in range(num_segments)]
+        caches = _empty_caches(model, B, device)
+        outputs, _ = checkpointed_sequence(model.chunk_step, segments, caches)
+        loss = torch.cat(outputs, dim=1).sum()
+        loss.backward()
+
+    def measure(fn):
+        gc.collect()
+        if device.type == 'cuda':
+            torch.cuda.empty_cache()
+            torch.cuda.synchronize()
+            torch.cuda.reset_peak_memory_stats(device)
+            fn()
+            torch.cuda.synchronize()
+            return torch.cuda.max_memory_allocated(device)
+        else: # mps
+            torch.mps.empty_cache()
+            torch.mps.synchronize()
+            baseline = torch.mps.driver_allocated_memory()
+            fn()
+            torch.mps.synchronize()
+            return torch.mps.driver_allocated_memory() - baseline
+
+    # warmup
+    measure(run_full)
+    measure(run_checkpointed)
+
+    mem_full = measure(run_full)
+    mem_ckpt = measure(run_checkpointed)
+
+    print(f"\nFull (1 x {L}): {mem_full / 1e6:.1f} MB")
+    print(f"Checkpointed ({num_segments} x {segment_size}): {mem_ckpt / 1e6:.1f} MB")
+    print(f"Reduction: {(1 - mem_ckpt / mem_full) * 100:.1f}%")
+
+    assert mem_ckpt * 5 < mem_full


### PR DESCRIPTION
At Datadog, we use Mamba on sequences of 10,000+ tokens. Training with full BPTT on those sequences was not feasible due to GPU memory constraints. To solve this, I implemented a custom activation checkpointing mechanism that enables back-propagation through virtually infinite sequences with constant memory usage, in exchange for some recompute. This was a key factor (among other changes) in improving generalisation on sequence length.

Standard PyTorch checkpointing (torch.utils.checkpoint) doesn't work here because pscan operates in-place. Instead, this custom SequenceCheckpoint stores only the small state tensors (h, conv_state) at segment boundaries — not the full activations. During backward, it recomputes activations one segment at a time while propagating gradients through the state across segments.

Changes
  - mambapy/checkpointing.py — SequenceCheckpoint (custom autograd.Function) and checkpointed_sequence() wrapper
  - mambapy/mamba.py — Mamba.checkpointed_chunk_step(x_seq, caches, segment_size) convenience method
  - tests/test_checkpointing.py — correctness test (gradients match full forward) and memory reduction test

  Tests
  - Mathematical Correctness: Full forward+backward gradients matches 2-segment checkpointed (rtol=1e-5)
  - Peak memory reduced by >5× (83% reduction measured) when performing activation checkpointing on 10 segments of 100 instead of a sequence of 1000